### PR TITLE
feat: Assume package dependencies are in sibling directories, instead…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,45 @@
 const nodePath = require('path');
-const resolve = require('resolve');
+const regexIsCompat = /\.js$/;
+const regexIsRelative = /^\./;
 
 function webify(path) {
-  const specifier = path.node.source.value;
-  const filename = this.file.opts.filename;
-  const base = nodePath.dirname(
-    nodePath.join(process.cwd(), filename)
-  );
+  const { source } = path.node;
+  const { value } = source;
+  const isRelative = regexIsRelative.test(value);
 
-  const pth = resolve.sync(specifier, {
-    basedir: base
-  });
-  const rel = nodePath.relative(base, pth);
-  const res = rel[0] === '.' ? rel : `./${rel}`;
+  // If it's module compatible, we simply let it pass through.
+  if (regexIsCompat.test(value)) {
+    return;
+  }
 
-  path.node.source.value = res;
+  const { filename } = this.file.opts;
+  const dir = nodePath.dirname(filename);
+
+  // If the module is specified as a relative path, we resolve it relative to
+  // the current module, otherwise we just pass it through. Otherwise, the name
+  // is just passed through. This assumes no absolute paths will be used.
+  const mod = isRelative ? nodePath.resolve(dir, value) : value;
+
+  // We then resolve the module using the standard method. The node-resolve
+  // package didn't seem to work and would always error out. No idea why, but
+  // it just kept saying it couldn't resolve the module relative to the path.
+  // I tried everything, even specifying odd values for options, but in the end
+  // it turns out that it's almost just as much code to do it with the standard
+  // Node API.
+  const pth = require.resolve(mod);
+
+  // We now have to transform it back to a relative path.
+  const rel = nodePath.relative(dir, pth);
+
+  // Modules that were originally specified as relative paths end up having the
+  // relative specifier knocked off of them. This is okay for web-only modules,
+  // but it could confuse bundlers if they use the ES source, so we make it
+  // work for both by prepending "./".
+  //
+  // Non-relative paths are considered paths to external libs. We implicitly
+  // require that these external libs have the same path, relative to the
+  // current module as a sibling.
+  source.value = isRelative ? `./${rel}` : `../${rel}`;
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function webify(path) {
   const { value } = source;
   const isRelative = regexIsRelative.test(value);
 
-  // If it's module compatible, we simply let it pass through.
+  // If it's web compatible, we simply let it pass through.
   if (regexIsCompat.test(value)) {
     return;
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,5 @@
   "scripts": {
     "test": "node test/test.js"
   },
-  "dependencies": {
-    "resolve": "^1.3.3"
-  }
+  "dependencies": {}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -9,7 +9,7 @@ const testCases = [
   },
   {
     before: "import foo from 'example'",
-    after: "import foo from './node_modules/example/github.js';"
+    after: "import foo from '../node_modules/example/github.js';"
   }
 ]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,7 +177,7 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-example@^0.0.0:
+example@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/example/-/example-0.0.0.tgz#510cb4d65a9f742ceba236920ec7c508a65954f6"
 
@@ -268,10 +268,6 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-parse@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
-
 private@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
@@ -285,12 +281,6 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
-
-resolve@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
-  dependencies:
-    path-parse "^1.0.5"
 
 slash@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
… of relative to the current file.

This means that you don't have to manually copy dependencies, they just use package management, or manual install as siblings.

This also fixes issues I was having with node-resolve that just was flat-out not working. I changed it to just use standard node stuff.

BREAKING CHANGE: Assumes sibling directories for package dependencies, instead of relative to the file importing it.